### PR TITLE
Lwt engine loop

### DIFF
--- a/unix/entropy_unix.ml
+++ b/unix/entropy_unix.ml
@@ -75,7 +75,7 @@ let refeed size fd f =
  * system instead of forcing the `period`.
  *)
 let handler t f =
-  let trigger _ = async @@ fun () -> refeed chunk t.fd f in
+  let trigger _ = async (fun () -> refeed chunk t.fd f) in
   stop t;
   refeed 32 t.fd f >|= fun () ->
   let ev = Lwt_engine.on_timer period true trigger in


### PR DESCRIPTION
Get rid of manual looping and use `Lwt_engine.on_timer`.
