### PR TITLE
disable mirage-entropy on xen for now (better safe than sorry)

### DIFF
--- a/xen/entropy_xen.ml
+++ b/xen/entropy_xen.ml
@@ -39,9 +39,7 @@ type handler = source:int -> buffer -> unit
 type t = { mutable handler : handler option }
 
 let connect () =
-  Random.self_init ();
-  print_endline "Entropy_xen_weak: using a weak entropy source seeded only from time.";
-  return (`Ok { handler = None })
+  return (`Error (`No_entropy_device "nothing on XEN yet, sorry"))
 
 let disconnect _ = return_unit
 
@@ -49,6 +47,7 @@ let id _ = ()
 
 let chunk = 16
 
+(* this code is using OCaml's weak RNG, better not use it *)
 let refeed t =
   match t.handler with
   | None   -> ()


### PR DESCRIPTION
OCaml's `random` is a LFSR, seeded with the current time. This is very predictable, especially since services might expose uptime information. I'm very much in favor of being better safe than sorry, and enabling mirage-entropy only after we have it in a decent state on Xen. @pqwy shares this opinion I believe.

@avsm are you ok with merging?