### PR TITLE
xen: support both entropy from dom0 and our weak fallback

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+trunk (unreleased):
+* xen: read entropy from a Xen PV device
+
 0.2.0 (16-Aug-2014):
 * Do not wrap `Entropy_unix` in a functor as it is meant to be used directly.
 

--- a/build
+++ b/build
@@ -3,7 +3,11 @@
 OS=${OS:-unix}
 OCAMLBUILD=ocamlbuild
 
-ocamlbuild -use-ocamlfind \
+case "${OS}" in
+xen) EXTRA_PKG="-pkg mirage-console.xen";;
+esac
+
+ocamlbuild -use-ocamlfind $EXTRA_PKG \
   -syntax camlp4o \
   -pkg cstruct \
   -pkg cstruct.lwt \

--- a/xen/META
+++ b/xen/META
@@ -1,6 +1,6 @@
 version = "0.2.0"
 description = "Entropy implementation for Xen"
-requires = "cstruct lwt mirage-types"
+requires = "cstruct lwt mirage-types mirage-console.xen"
 archive(byte) = "mirage-entropy.cma"
 archive(byte, plugin) = "mirage-entropy.cma"
 archive(native) = "mirage-entropy.cmxa"

--- a/xen/entropy_xen.ml
+++ b/xen/entropy_xen.ml
@@ -2,6 +2,7 @@
  * Copyright (c) 2014, Hannes Mehnert
  * Copyright (c) 2014 Anil Madhavapeddy <anil@recoil.org>
  * Copyright (c) 2014 David Kaloper
+ * Copyright (c) 2015 Citrix Systems Inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,38 +29,88 @@
 
 open Lwt
 
-type id = unit
-
 type 'a io  = 'a Lwt.t
 type buffer = Cstruct.t
 type error  = [ `No_entropy_device of string ]
 
 type handler = source:int -> buffer -> unit
 
-type t = { mutable handler : handler option }
+type id = [ `FromHost | `Weak ]
 
-let connect () =
+type t =
+| RandomSelfInit (* Implementation of `Weak *)
+| EntropyConsole of Console_xen.t (* Implementation of `FromHost *)
+
+let id = function
+| RandomSelfInit -> `Weak
+| EntropyConsole _ -> `FromHost
+
+(* These are defined in xentropy/doc/protocol.md *)
+let console_name = "org.openmirage.entropy.1"
+let handshake_message =
+  let string = "Hello, may I have some entropy?\r\n" in
+  let buffer = Cstruct.create (String.length string) in
+  Cstruct.blit_from_string string 0 buffer 0 (String.length string);
+  buffer
+let handshake_response = "You may treat everything following this message as entropy.\r\n"
+
+let (>>|=) x f = x >>= function
+| `Ok x -> f x
+| `Eof ->
+  print_endline "Received an EOF from the entropy console";
+  return (`Error (`No_entropy_device console_name))
+| `Error (`Invalid_console x) ->
+  Printf.printf "Invalid_console %s\n%!" x;
+  return (`Error (`No_entropy_device console_name))
+| `Error _ ->
+  Printf.printf "Unknown console device failure\n%!";
+  return (`Error (`No_entropy_device console_name))
+
+let connect = function
+| `Weak ->
   Random.self_init ();
-  print_endline "Entropy_xen_weak: using a weak entropy source seeded only from time.";
-  return (`Ok { handler = None })
+  print_endline "Entropy_xen: using a weak entropy source seeded only from time.";
+  return (`Ok RandomSelfInit)
+| `FromHost ->
+  Printf.printf "Entropy_xen: attempting to connect to Xen entropy source %s\n%!" console_name;
+  Console_xen.connect console_name
+  >>|= fun device ->
+  Console_xen.write device handshake_message
+  >>|= fun () ->
+  Console_xen.read device
+  >>|= fun buffer ->
+  let string = Cstruct.to_string buffer in
+  if string <> handshake_response then begin
+    Printf.printf "Entropy_xen: received [%s](%d bytes) instead of expected handshake message"
+      (String.escaped string) (String.length string);
+    return (`Error (`No_entropy_device console_name))
+  end else begin
+    print_endline "Entropy_xen: connected to Xen entropy source";
+    return (`Ok (EntropyConsole device))
+  end
 
 let disconnect _ = return_unit
 
-let id _ = ()
-
 let chunk = 16
 
-let refeed t =
-  match t.handler with
-  | None   -> ()
-  | Some f ->
-      let s  = Random.int 256
-      and cs = Cstruct.create chunk in
-      for i = 0 to chunk - 1 do
-        Cstruct.set_uint8 cs i Random.(int 256)
-      done ;
-      f ~source:s cs
+let refeed t f = match t with
+| EntropyConsole console ->
+  Console_xen.read console
+  >>|= fun cs ->
+  f ~source:(Cstruct.get_uint8 cs 0) (Cstruct.shift cs 1);
+  return (`Ok ())
+| RandomSelfInit ->
+  let s  = Random.int 256
+  and cs = Cstruct.create chunk in
+  for i = 0 to chunk - 1 do
+    Cstruct.set_uint8 cs i Random.(int 256)
+  done ;
+  f ~source:s cs;
+  return (`Ok ())
 
-let handler t f =
-  t.handler <- Some f ; refeed t ; return_unit
+let handler t f : unit Lwt.t =
+  (* Read data from the console and advertise it.
+     FIXME: we should do this more than once. How often? *)
+  let (_: 'a Lwt.t) = refeed t f in
+  return_unit
 

--- a/xen/entropy_xen.ml
+++ b/xen/entropy_xen.ml
@@ -27,6 +27,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *)
 
+let period = 600. (* refeed every <period> seconds *)
+let chunk = 16    (* read <chunk> bytes of entropy every <period> *)
+
 open Lwt
 
 type 'a io  = 'a Lwt.t
@@ -37,11 +40,16 @@ type handler = source:int -> buffer -> unit
 
 type id = [ `FromHost | `Weak ]
 
-type t =
+type implementation =
 | RandomSelfInit (* Implementation of `Weak *)
 | EntropyConsole of Console_xen.t (* Implementation of `FromHost *)
 
-let id = function
+type t = {
+  implementation: implementation;
+  mutable ev: Lwt_engine.event option;
+}
+
+let id t = match t.implementation with
 | RandomSelfInit -> `Weak
 | EntropyConsole _ -> `FromHost
 
@@ -70,7 +78,7 @@ let connect = function
 | `Weak ->
   Random.self_init ();
   print_endline "Entropy_xen: using a weak entropy source seeded only from time.";
-  return (`Ok RandomSelfInit)
+  return (`Ok { implementation = RandomSelfInit; ev = None })
 | `FromHost ->
   Printf.printf "Entropy_xen: attempting to connect to Xen entropy source %s\n%!" console_name;
   Console_xen.connect console_name
@@ -86,19 +94,24 @@ let connect = function
     return (`Error (`No_entropy_device console_name))
   end else begin
     print_endline "Entropy_xen: connected to Xen entropy source";
-    return (`Ok (EntropyConsole device))
+    return (`Ok { implementation = EntropyConsole device; ev = None })
   end
 
 let disconnect _ = return_unit
 
-let chunk = 16
-
-let refeed t f = match t with
+let refeed t f = match t.implementation with
 | EntropyConsole console ->
-  Console_xen.read console
-  >>|= fun cs ->
+  ( Console_xen.read console
+    >>= function
+    | `Ok cs ->
+      return cs
+    | _ ->
+      Printf.printf "ERROR: reading from entropy device. We have no more entropy\n%!";
+      (* Abort the unikernel *)
+      failwith "Unable to read from entropy device"
+  ) >>= fun cs ->
   f ~source:(Cstruct.get_uint8 cs 0) (Cstruct.shift cs 1);
-  return (`Ok ())
+  return_unit
 | RandomSelfInit ->
   let s  = Random.int 256
   and cs = Cstruct.create chunk in
@@ -106,11 +119,29 @@ let refeed t f = match t with
     Cstruct.set_uint8 cs i Random.(int 256)
   done ;
   f ~source:s cs;
-  return (`Ok ())
+  return_unit
+
+let stop t =
+  match t.ev with
+  | None    -> ()
+  | Some ev -> Lwt_engine.stop_event ev ; t.ev <- None
+
+(*
+ * Registering a `handler` spins up a recurrent timer.
+ *
+ * XXX There should be no timer in the first place; `refeed` should piggyback
+ * on other activity going on in the system. We should trigger refeeding every
+ * time the engine fires some _other_ callback, throttling the frequency. That
+ * way, refeeding would be broadly aligned with the general activity of the
+ * system instead of forcing the `period`.
+ *)
 
 let handler t f : unit Lwt.t =
-  (* Read data from the console and advertise it.
-     FIXME: we should do this more than once. How often? *)
-  let (_: 'a Lwt.t) = refeed t f in
+  let trigger _ = async (fun () -> refeed t f) in
+  stop t;
+  refeed t f
+  >>= fun () ->
+  let ev = Lwt_engine.on_timer period true trigger in
+  t.ev <- Some ev;
   return_unit
 

--- a/xen/entropy_xen.mli
+++ b/xen/entropy_xen.mli
@@ -25,4 +25,5 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *)
 
-include V1_LWT.ENTROPY with type id = [ `FromHost | `Weak ]
+module Make(T : V1_LWT.TIME): V1_LWT.ENTROPY
+  with type id = [ `FromHost | `Weak ]

--- a/xen/entropy_xen.mli
+++ b/xen/entropy_xen.mli
@@ -25,4 +25,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *)
 
-include V1_LWT.ENTROPY with type id = unit
+include V1_LWT.ENTROPY with type id = [ `FromHost | `Weak ]


### PR DESCRIPTION
Support 2 kinds of entropy source:

- `FromHost`: we receive entropy over a console from domain 0 (or whichever other privileged domain has the entropy). This should be strong, but it requires an entropy server i.e. `xentropyd`
- `Weak`: we use `Random.self_init` and get entropy from the clock. This is weak but will work anywhere.

In future we should support `RDSEED` #9 and possibly entropy from interrupt timing #10

Depends on [mirage/mirage#359]

Signed-off-by: David Scott <dave.scott@citrix.com>