### PR TITLE
Armed and volatile

### DIFF
--- a/lib/entropy_cpu_xen_stubs.c
+++ b/lib/entropy_cpu_xen_stubs.c
@@ -59,20 +59,6 @@ static void detect () {
       if (ebx & bit_RDSEED) __cpu_rng = RNG_RDSEED;
     }
   }
-
-#elif defined (__ARM_ARCH_7A__) && 0
-/* XXX:
- * The ideal timing source on ARM are the performance counters, but these are
- * presently masked by Xen.
- * Matches with the bit in caml_cycle_counter.
- */
-  /* Disable counter overflow interrupts. */
-  __asm__ __volatile__ ("mcr p15, 0, %0, c9, c14, 2" :: "r"(0x8000000f));
-  /* Program the PMU control register. */
-  __asm__ __volatile__ ("mcr p15, 0, %0, c9, c12, 0" :: "r"(1 | 16));
-  /* Enable all counters. */
-  __asm__ __volatile__ ("mcr p15, 0, %0, c9, c12, 1" :: "r"(0x8000000f));
-
 #endif
 }
 
@@ -81,10 +67,6 @@ CAMLprim value caml_cycle_counter (value unit) {
   return Val_long (__rdtsc ());
 #elif defined (__arm__)
   return Val_long (read_virtual_count ());
-#elif defined (__ARM_ARCH_7A__) && 0
-  unsigned int res;
-  __asm__ __volatile__ ("mrc p15, 0, %0, c9, c13, 0": "=r" (res));
-  return Val_long (res);
 #else
 #error ("No known cycle-counting instruction.")
 #endif
@@ -113,3 +95,22 @@ CAMLprim value caml_entropy_xen_detect (value unit) {
   detect ();
   return Val_unit;
 }
+
+/*
+ * XXX
+ * The ideal timing source on ARM are the performance counters, but these are
+ * presently masked by Xen.
+ * It would work like this:
+
+#if defined (__ARM_ARCH_7A__)
+  // Disable counter overflow interrupts.
+  __asm__ __volatile__ ("mcr p15, 0, %0, c9, c14, 2" :: "r"(0x8000000f));
+  // Program the PMU control register.
+  __asm__ __volatile__ ("mcr p15, 0, %0, c9, c12, 0" :: "r"(1 | 16));
+  // Enable all counters.
+  __asm__ __volatile__ ("mcr p15, 0, %0, c9, c12, 1" :: "r"(0x8000000f));
+
+  // Read:
+  unsigned int res;
+  __asm__ __volatile__ ("mrc p15, 0, %0, c9, c13, 0": "=r" (res));
+*/

--- a/lib/entropy_cpu_xen_stubs.c
+++ b/lib/entropy_cpu_xen_stubs.c
@@ -24,6 +24,17 @@
 #endif
 #endif /* __i386__ || __x86_64__ */
 
+#if defined (__arm__)
+
+/* Replace with `read_virtual_count` from MiniOS when that symbol
+ * gets exported. */
+static inline uint32_t read_virtual_count () {
+  uint32_t c_lo, c_hi;
+  __asm__ __volatile__("mrrc p15, 1, %0, %1, c14":"=r"(c_lo), "=r"(c_hi));
+  return c_lo;
+}
+#endif /* arm */
+
 enum cpu_rng_t {
   RNG_NONE   = 0,
   RNG_RDRAND = 1,
@@ -68,6 +79,8 @@ static void detect () {
 CAMLprim value caml_cycle_counter (value unit) {
 #if defined (__x86__)
   return Val_long (__rdtsc ());
+#elif defined (__arm__)
+  return Val_long (read_virtual_count ());
 #elif defined (__ARM_ARCH_7A__) && 0
   unsigned int res;
   __asm__ __volatile__ ("mrc p15, 0, %0, c9, c13, 0": "=r" (res));


### PR DESCRIPTION
Sadly, ARM performance counters are masked on Xen. For a decidedly more pleasant timing experience, we should get that working, but for the time being, `CNTVCT` and the bootstrap code provide something half-way decent.

Many thanks to @talex5 who spent some hours in front of my monitor while we were trying to figure out why exactly the performance counter readings always return `0`. ([Because](https://github.com/mirage/xen/blob/123c7793797502b222300eb710cd3873dcca41ee/xen/arch/arm/traps.c#L1603) [reasons](https://github.com/mirage/xen/blob/123c7793797502b222300eb710cd3873dcca41ee/xen/arch/arm/traps.c#L1643).)

This is not quite the ideal state for ARM, but pending reactivation of `xentropyd` and hopefully full perf counters, it's a solid stop-gap measure.