### PR TITLE
use runtime hooks instead of mirage-os-shims

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,3 @@
 B _build/**
 FLG -w A-4-6-44-48-58
-PKG cstruct lwt mirage-os-shim
+PKG cstruct lwt mirage-runtime mirage-unix

--- a/_tags
+++ b/_tags
@@ -3,8 +3,8 @@ true : warn(+A-4-6-44-48-58)
 true : package(cstruct), package(lwt)
 
 <lib> : include
-<lib/*.ml> : package(mirage-os-shim)
+<lib/*.ml> : package(mirage-runtime)
 <lib/mirage-entropy.{cma,cmxa}> : link_stubs(lib/libmirage-entropy_stubs)
 <**/*.c> : ccopt(-O3 -std=c99 -Wall -Wpedantic)
 
-<test/*>: package(mirage-os-shim), predicate(mirage_unix), use_mirage-entropy
+<test/*>: package(mirage-runtime mirage-unix), use_mirage-entropy

--- a/lib/entropy.ml
+++ b/lib/entropy.ml
@@ -45,7 +45,6 @@ module Cpu_native = struct
 end
 
 open Lwt.Infix
-open Mirage_OS
 
 type 'a io   = 'a Lwt.t
 type buffer  = Cstruct.t
@@ -117,7 +116,7 @@ let interrupt_hook () =
 let connect () =
   let t    = { handlers = [] ; inits = [ bootstrap ] }
   and hook = interrupt_hook () in
-  OS.Main.at_enter_iter (fun () ->
+  Mirage_runtime.at_enter_iter (fun () ->
     match t.handlers with
     | [] -> ()
     | xs -> let e = hook () in List.iter (fun h -> h ~source:0 e) xs) ;
@@ -134,4 +133,3 @@ let remove_handler t token =
 let disconnect t =
   t.handlers <- [] ;
   Lwt.return_unit
-

--- a/opam
+++ b/opam
@@ -20,7 +20,8 @@ depends: [
   "ocb-stubblr" {build}
   "ocaml" {>= "4.04.2"}
   "cstruct"
-  "mirage-os-shim"
+  "mirage-runtime"
+  "mirage-unix" {test}
   "lwt"
 ]
 depopts: [

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 description = "Entropy provider for MirageOS"
 version = "%%VERSION_NUM%%"
-requires = "lwt cstruct mirage-os-shim"
+requires = "lwt cstruct mirage-runtime"
 archive(byte) = "mirage-entropy.cma"
 archive(native) = "mirage-entropy.cmxa"
 plugin(byte) = "mirage-entropy.cma"

--- a/test/test.ml
+++ b/test/test.ml
@@ -19,5 +19,5 @@ let with_entropy act =
         Entropy.disconnect t >|= fun () -> res
 
 let () =
-  Mirage_OS.OS.(Main.run (with_entropy (fun () ->
+  OS.(Main.run (with_entropy (fun () ->
     Time.sleep_ns 1_000L)))


### PR DESCRIPTION
This is based on top of #41 and requires https://github.com/mirage/mirage/pull/1010 and https://github.com/mirage/mirage-unix/pull/14 to build