### PR TITLE
mirage 3.7.0 changes

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,3 @@
 B _build/**
 FLG -w A-4-6-44-48-58
-PKG cstruct lwt mirage-os-shim
+PKG cstruct lwt mirage-runtime mirage-unix

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
-sudo: required
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
+sudo: false
+services:
+  - docker
 env:
   global:
     - PACKAGE="mirage-entropy"
-    - UPDATE_GCC_BINUTILS=1
+    - DISTRO=alpine
+    - TESTS=true
   matrix:
-    - OCAML_VERSION=4.04
-    - OCAML_VERSION=4.04 DEPOPTS=mirage-xen
-    - OCAML_VERSION=4.04 DEPOPTS="mirage-solo5 ocaml-freestanding"
-    - OCAML_VERSION=4.05
-    - OCAML_VERSION=4.05 DEPOPTS=mirage-xen
-    - OCAML_VERSION=4.05 DEPOPTS="mirage-solo5 ocaml-freestanding"
-    - OCAML_VERSION=4.06
     - OCAML_VERSION=4.06 DEPOPTS="mirage-solo5 ocaml-freestanding"
+    - OCAML_VERSION=4.07 DEPOPTS=mirage-xen
+    - OCAML_VERSION=4.08
+    - OCAML_VERSION=4.09 DEPOPTS="mirage-solo5 ocaml-freestanding"
 notifications:
   email: false

--- a/_tags
+++ b/_tags
@@ -3,8 +3,8 @@ true : warn(+A-4-6-44-48-58)
 true : package(cstruct), package(lwt)
 
 <lib> : include
-<lib/*.ml> : package(mirage-os-shim)
+<lib/*.ml> : package(mirage-runtime)
 <lib/mirage-entropy.{cma,cmxa}> : link_stubs(lib/libmirage-entropy_stubs)
 <**/*.c> : ccopt(-O3 -std=c99 -Wall -Wpedantic)
 
-<test/*>: package(mirage-os-shim), predicate(mirage_unix), use_mirage-entropy
+<test/*>: package(mirage-runtime mirage-unix), use_mirage-entropy

--- a/lib/entropy.ml
+++ b/lib/entropy.ml
@@ -45,7 +45,6 @@ module Cpu_native = struct
 end
 
 open Lwt.Infix
-open Mirage_OS
 
 type 'a io   = 'a Lwt.t
 type buffer  = Cstruct.t
@@ -117,7 +116,7 @@ let interrupt_hook () =
 let connect () =
   let t    = { handlers = [] ; inits = [ bootstrap ] }
   and hook = interrupt_hook () in
-  OS.Main.at_enter_iter (fun () ->
+  Mirage_runtime.at_enter_iter (fun () ->
     match t.handlers with
     | [] -> ()
     | xs -> let e = hook () in List.iter (fun h -> h ~source:0 e) xs) ;
@@ -134,4 +133,3 @@ let remove_handler t token =
 let disconnect t =
   t.handlers <- [] ;
   Lwt.return_unit
-

--- a/opam
+++ b/opam
@@ -17,12 +17,12 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ocb-stubblr" {build}
+  "ocb-stubblr" {build & >= "0.1.1-1"}
   "ocaml" {>= "4.04.2"}
-  "cstruct"
-  "mirage-runtime"
-  "mirage-unix" {test}
-  "lwt"
+  "cstruct" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.7.0"}
+  "lwt" {>= "4.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0"}
 ]
 depopts: [
   "mirage-solo5"
@@ -30,8 +30,6 @@ depopts: [
   "mirage-xen"
 ]
 conflicts: [
-  "ocb-stubblr" {<"0.1.0"}
-  "cstruct" {<"1.4.0"}
   "mirage-xen" {<"2.2.0"}
 ]
 tags: [ "org:mirage"]

--- a/opam
+++ b/opam
@@ -20,7 +20,8 @@ depends: [
   "ocb-stubblr" {build}
   "ocaml" {>= "4.04.2"}
   "cstruct"
-  "mirage-os-shim"
+  "mirage-runtime"
+  "mirage-unix" {test}
   "lwt"
 ]
 depopts: [

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 description = "Entropy provider for MirageOS"
 version = "%%VERSION_NUM%%"
-requires = "lwt cstruct mirage-os-shim"
+requires = "lwt cstruct mirage-runtime"
 archive(byte) = "mirage-entropy.cma"
 archive(native) = "mirage-entropy.cmxa"
 plugin(byte) = "mirage-entropy.cma"

--- a/test/test.ml
+++ b/test/test.ml
@@ -19,5 +19,5 @@ let with_entropy act =
         Entropy.disconnect t >|= fun () -> res
 
 let () =
-  Mirage_OS.OS.(Main.run (with_entropy (fun () ->
+  OS.(Main.run (with_entropy (fun () ->
     Time.sleep_ns 1_000L)))


### PR DESCRIPTION
depend on mirage-runtime for hooks, no mirage-os-shim anymore (this includes #45)